### PR TITLE
Add ability to play videos inline (and increase documentation)

### DIFF
--- a/TRVideoView/TRVideoView.swift
+++ b/TRVideoView/TRVideoView.swift
@@ -10,24 +10,41 @@ import UIKit
 import WebKit
 
 open class TRVideoView: WKWebView {
-    
     var text = ""
     var urls = [URL]()
-    
-    public convenience init(text: String) {
-        self.init(frame: CGRect(x: 0, y: 0, width: 340, height: 180))
+
+    private var playsInline: Bool = false
+
+    /// Allows you to initialize the view with a prepopulated text and customizing whether to play videos inline.
+    /// - Parameters:
+    ///   - text: The text to extract video urls from
+    ///   - allowInlinePlayback: Whether to allow video to play inline rather than always being full screen.
+    ///       If set to true, then video will start playing inline by default.
+    public convenience init(text: String, allowInlinePlayback: Bool = false) {
+        let webConfiguration = WKWebViewConfiguration()
+        if (allowInlinePlayback) {
+            webConfiguration.allowsInlineMediaPlayback = true
+            webConfiguration.mediaTypesRequiringUserActionForPlayback = []
+        }
+
+        self.init(frame: CGRect(x: 0, y: 0, width: 340, height: 180), configuration: webConfiguration)
+
+        self.playsInline = allowInlinePlayback
+
         self.text = text
         self.urls = text.extractURLs()
+
         self.scrollView.isScrollEnabled = false
+
         setup()
     }
-    
+
     open func containsURLs() -> Bool {
         if(self.urls.isEmpty){
             return false
         } else {
             var result = false
-            for url in self.urls{
+            for url in self.urls {
                 if(url.absoluteString.contains("youtu") || url.absoluteString.contains("vimeo.com")){
                     result = true
                 }
@@ -35,42 +52,47 @@ open class TRVideoView: WKWebView {
             return result
         }
     }
-    
+
     open func textWithoutURLs() -> String{
         var result = self.text
-        
+
         // If URL is in the middle of the text it will create a double space, but that's okay for now
         for url in self.urls {
             result = result.replacingOccurrences(of: "\(url.absoluteString)", with: "")
         }
-        
+
         return result
     }
-    
+
     func setup() {
-        
+
         for url in self.urls {
             
             // If vimeo URL embedded vimeo player
-            if(url.absoluteString.contains("vimeo.com")){
+            if(url.absoluteString.contains("vimeo.com")) {
                 print(url.pathComponents)
-                var link = url.lastPathComponent
-                link = "https://player.vimeo.com/video/"+link
+                let query = playsInline ? "?playsinline=1" : ""
+                let link = "https://player.vimeo.com/video/" + url.lastPathComponent + query
                 DispatchQueue.main.async(execute: { () -> Void in
                     self.loadHTMLString("<head> <meta name=viewport content='width=device-width, initial-scale=1'><style type='text/css'> body { margin: 0;} </style></head><iframe src='\(link)' width='100%' height='100%' frameborder='0' webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>", baseURL: nil)
                 })
-                
+
             // If YouTube URL embedded YouTube player
-            } else if(url.absoluteString.contains("youtu")){
-                
+            } else if(url.absoluteString.contains("youtu")) {
+
                 // Fool proof video ID decoding
-                var link = ""
+                let link: String
+
+                let host = "https://www.youtube.com/embed/"
+                let query = playsInline ? "?rel=0&playsinline=1" : "?rel=0"
                 if (url.host?.contains("youtube.com") ?? false) {
-                    link = "https://www.youtube.com/embed/"+url["v"]+"?rel=0"
+                    link = host + url["v"] + query
                 } else if (url.host?.contains("youtu.be") ?? false) {
-                    link = "https://www.youtube.com/embed/"+url.lastPathComponent+"?rel=0"
+                    link = host + url.lastPathComponent + query
+                } else {
+                    link = ""
                 }
-                
+
                 DispatchQueue.main.async(execute: { () -> Void in
                     self.loadHTMLString("<head> <meta name=viewport content='width=device-width, initial-scale=1'><style type='text/css'> body { margin: 0;} </style></head><iframe width='100%' height='100%' src='\(link)' frameborder='0' allowfullscreen></iframe>", baseURL: nil)
                 })


### PR DESCRIPTION
The main purpose of this PR is to add an optional parameter to the convenience initializer of this class called `allowInlinePlayback`. If `true` is passed to it, then the view will be set up so that it will play videos inline, within the bounds of the view, by default and the user will have to manually fullscreen them.

The secondary purpose of this PR, because I'm easily distracted, is to revamp the documentation of the class so that XCode tool tips will provide more details about what's going on with the exposed methods and so that some behavior developers might have expected (like setting `text` after initialization causing the view to update) occur.